### PR TITLE
Patching bugs in #5

### DIFF
--- a/thingiverse_downloader/__init__.py
+++ b/thingiverse_downloader/__init__.py
@@ -66,6 +66,8 @@ class ThingiverseDownloaderPlugin(octoprint.plugin.TemplatePlugin,
             if name is None:
                 return self.return_response(result, "A name could not be parsed from the Thingiverse item.")
 
+            name = name.encode('ascii', 'ignore')
+
             FILES_URL = "{0}/{1}/files/{2}".format(BASE_URL, THING_ID,
                                                    PARAM_ACCESS_TOKEN)
 

--- a/thingiverse_downloader/static/css/thingiverse_downloader.css
+++ b/thingiverse_downloader/static/css/thingiverse_downloader.css
@@ -42,7 +42,6 @@
 }
 
 .thingiverse-downloader-result-state {
-  color: #333;
   font-size: 14px;
   -webkit-text-size-adjust: 100%;
   margin: 4px;

--- a/thingiverse_downloader/static/js/thingiverse_downloader.js
+++ b/thingiverse_downloader/static/js/thingiverse_downloader.js
@@ -10,6 +10,13 @@ $(function () {
 
         self.result = ko.observable();
 
+        self.thingUrl.subscribe(function (newValue) {
+            if (newValue === "") {
+                self.loading(false);
+                self.result(null);
+            }
+        });
+
         self.onBeforeBinding = function () {
             self.thingUrl("");
             self.loading(false);
@@ -33,6 +40,7 @@ $(function () {
 
         self.downloadUrlFiles = function () {
             self.loading(true);
+            self.result(null);
             $.ajax({
                 url: API_BASEURL + "plugin/thingiverse_downloader",
                 type: "POST",

--- a/thingiverse_downloader/static/js/thingiverse_downloader.js
+++ b/thingiverse_downloader/static/js/thingiverse_downloader.js
@@ -10,9 +10,8 @@ $(function () {
 
         self.result = ko.observable();
 
-        self.thingUrl.subscribe(function (newValue) {
-            if (newValue === "") {
-                self.loading(false);
+        self.thingUrl.subscribe(function () {
+            if (self.result() != null && self.loading() === false) {
                 self.result(null);
             }
         });


### PR DESCRIPTION
# Issues

Closes #5 

# Summary

- Removes black text color from CSS for `Download Status`
- Fixes download failures due to invalid characters in thing name, such as ä, ö, ü, etc.
- Reset Download Status accordingly.