### PR TITLE
Feature#1#2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Download and extract a thing from Thingiverse to your Octoprint instance, given 
 [![GitHub issues](https://img.shields.io/github/issues/appdevelopmentandsuch/Thingiverse-Downloader.svg)](https://GitHub.com/appdevelopmentandsuch/Thingiverse-Downloader/issues/)
 [![GitHub issues-closed](https://img.shields.io/github/issues-closed/appdevelopmentandsuch/Thingiverse-Downloader.svg)](https://GitHub.com/appdevelopmentandsuch/Thingiverse-Downloader/issues?q=is%3Aissue+is%3Aclosed)
 
-![Thingiverse-Downloader-Demo-URL](https://user-images.githubusercontent.com/22528729/132111135-e4d87087-5645-49ed-ab6e-7c855ba8c664.gif)
-![Thingiverse-Downloader-Demo-ID](https://user-images.githubusercontent.com/22528729/132111134-a3c50855-d993-4b00-a5cb-8dcd93e94815.gif)
+![Thingiverse-Downloader-Demo-URL](https://user-images.githubusercontent.com/22528729/132139046-1b1b4dc5-dfb8-4084-bb2d-1d3c27e53bb4.gif)
+![Thingiverse-Downloader-Demo-ID](https://user-images.githubusercontent.com/22528729/132139044-446589ee-4ab9-4962-ac1d-04c991062782.gif)
 
 ## Setup
 

--- a/thingiverse_downloader/__init__.py
+++ b/thingiverse_downloader/__init__.py
@@ -94,8 +94,11 @@ class ThingiverseDownloaderPlugin(octoprint.plugin.TemplatePlugin,
             thing = self.get_thing_from_thingiverse(thing_id, ACCESS_TOKEN)
 
             if command == "download":
+                override_name = data.get("override_name", "")
 
-                name = thing.get('name', '').encode(
+                name = override_name if override_name != "" else thing.get(
+                    'name', '')
+                name = name.encode(
                     'ascii', 'ignore').decode("utf-8")  # Remove filename unsafe characters
 
                 if name == '':

--- a/thingiverse_downloader/__init__.py
+++ b/thingiverse_downloader/__init__.py
@@ -4,6 +4,7 @@ import requests
 import flask
 import os
 import octoprint.plugin
+import octoprint.settings
 
 
 class ThingiverseDownloaderPlugin(octoprint.plugin.TemplatePlugin,
@@ -11,7 +12,7 @@ class ThingiverseDownloaderPlugin(octoprint.plugin.TemplatePlugin,
                                   octoprint.plugin.SimpleApiPlugin,
                                   octoprint.plugin.SettingsPlugin):
     def get_settings_defaults(self):
-        return {"api_key": None, "output_directory": "/home/pi/.octoprint/uploads/models"}
+        return {"api_key": None, "output_directory": "models"}
 
     def get_assets(self):
         return dict(
@@ -27,7 +28,7 @@ class ThingiverseDownloaderPlugin(octoprint.plugin.TemplatePlugin,
 
     def get_api_commands(self):
         return dict(
-            download=["url"]
+            download=["url", "override_name"], preview=["url"]
         )
 
     def return_response(self, result, error=None):
@@ -61,7 +62,10 @@ class ThingiverseDownloaderPlugin(octoprint.plugin.TemplatePlugin,
 
             r = requests.get(url=URL)
 
-            name = r.json().get('name', None)
+            uploads_dir = octoprint.settings.Settings().getBaseFolder("uploads")
+
+            OUTPUT_DIRECTORY = "{0}/{1}".format(uploads_dir, self._settings.get(
+                ["output_directory"]).rstrip('/'))
 
             if name is None:
                 return self.return_response(result, "A name could not be parsed from the Thingiverse item.")

--- a/thingiverse_downloader/static/css/thingiverse_downloader.css
+++ b/thingiverse_downloader/static/css/thingiverse_downloader.css
@@ -65,10 +65,6 @@
 
 .thingiverse-downloader-preview-container-visible {
   height: 260px;
-}
-
-.thingiverse-downloader-preview-container-visible {
-  height: 260px;
   background: #eeeeee;
   border-radius: 10px;
 }

--- a/thingiverse_downloader/static/css/thingiverse_downloader.css
+++ b/thingiverse_downloader/static/css/thingiverse_downloader.css
@@ -3,9 +3,8 @@
   flex-direction: column;
 }
 
-.thingiverse-downloader-input-title {
-  font-weight: bold;
-  margin-right: 8px;
+.thingiverse-downloader-thing-input {
+  width: -webkit-fill-available;
 }
 
 .thingiverse-downloader-settings-row {
@@ -23,10 +22,18 @@
 
 .thingiverse-downloader-input-wrapper {
   display: flex;
+  flex-direction: column;
+  /* align-items: baseline; */
+  margin: 4px 0;
+  padding: 8px;
+  background: #eeeeee;
+  border-radius: 10px;
+}
+
+.thingiverse-downloader-input-row {
+  display: flex;
   flex-direction: row;
   align-items: baseline;
-  margin: 4px;
-  padding: 4px;
 }
 
 .thingiverse-downloader-settings-container {
@@ -35,15 +42,21 @@
   align-items: flex-start;
 }
 
-.thingiverse-downloader-loading-icon {
-  width: fit-content;
+.thingiverse-downloader-preview-name {
+  font-size: larger;
+  margin: 0 4px;
+  padding: 0 4px;
+  color: #393e46;
+}
+
+.thingiverse-downloader-preview-img {
+  width: 50% !important;
   margin: 4px;
   padding: 4px;
 }
 
-.thingiverse-downloader-result-state {
-  font-size: 14px;
-  -webkit-text-size-adjust: 100%;
-  margin: 4px;
-  padding: 4px;
+.thingiverse-downloader-preview-container-visible {
+  height: 260px;
+  background: #eeeeee;
+  border-radius: 10px;
 }

--- a/thingiverse_downloader/static/js/thingiverse_downloader.js
+++ b/thingiverse_downloader/static/js/thingiverse_downloader.js
@@ -6,7 +6,9 @@ $(function () {
 
         self.thingUrl = ko.observable();
 
-        self.loading = ko.observable();
+        self.overrideName = ko.observable("");
+
+        self.loading = ko.observable(false);
 
         self.result = ko.observable();
 

--- a/thingiverse_downloader/static/js/thingiverse_downloader.js
+++ b/thingiverse_downloader/static/js/thingiverse_downloader.js
@@ -34,8 +34,9 @@ $(function () {
             self.result(null);
         });
 
-        self.clearThingUrl = function () {
+        self.clearAll = function () {
             self.thingUrl("");
+            self.overrideName("");
         };
 
         self.fetchPreviewImage = function () {
@@ -67,6 +68,7 @@ $(function () {
                     JSON.stringify({
                         command: "download",
                         url: self.thingUrl(),
+                        override_name: self.overrideName(),
                     })
                 )
             )

--- a/thingiverse_downloader/templates/thingiverse_downloader_tab.jinja2
+++ b/thingiverse_downloader/templates/thingiverse_downloader_tab.jinja2
@@ -1,8 +1,31 @@
 <div class="thingiverse-downloader">
     <div class="thingiverse-downloader-input-wrapper">
-        <span class="thingiverse-downloader-input-title">Thingiverse URL</span>
-        <input type="text" class="input-large" data-bind="value: thingUrl"/>
-        <button class="btn btn-primary" data-bind="click: downloadUrlFiles">{{ _('Download') }}</button>
+        <div class="thingiverse-downloader-input-row">
+            <input 
+                type="text" 
+                class="input-large thingiverse-downloader-thing-input" 
+                data-bind="value: thingUrl, disable: loading" 
+                title="i.e. https://www.thingiverse.com/thing:123456 or 123456"
+                placeholder="Thingiverse URL or Thing ID"
+            >
+            <button class="btn" data-bind="click: downloadUrlFiles, disable: loading() || thingUrl() === '' || result() != null, class: downloadButtonClass()">
+                <i data-bind="class: downloadStateIcon()"></i>
+            </button>
+            <button type="reset" class="btn btn-primary" data-bind="click: downloadUrlFiles, disable: loading() || thingUrl() === '' || result() === null">
+                <i class="fas fa-redo-alt"></i>
+            </button>
+            <button type="reset" class="btn" data-bind="click: clearThingUrl, disable: loading() || thingUrl() === ''" title="Clear Text">
+                <i class="fas fa-times-circle"></i>
+            </button>
+        </div>
+        <div class="thingiverse-downloader-input-row">
+            <input 
+                    type="text" 
+                    class="input-large thingiverse-downloader-thing-input" 
+                    data-bind="value: overrideName, disable: loading"
+                    placeholder="Alternate name (optional)"
+                >
+        </div>
     </div>
 
     <span class="thingiverse-downloader-result-state" data-bind="html: getResultState()"></span>

--- a/thingiverse_downloader/templates/thingiverse_downloader_tab.jinja2
+++ b/thingiverse_downloader/templates/thingiverse_downloader_tab.jinja2
@@ -15,7 +15,7 @@
             <button type="reset" class="btn btn-primary" data-bind="click: downloadUrlFiles, disable: loading() || thingUrl() === '' || result() === null">
                 <i class="fas fa-redo-alt"></i>
             </button>
-            <button type="reset" class="btn" data-bind="click: clearThingUrl, disable: loading() || thingUrl() === ''" title="Clear Text">
+            <button type="reset" class="btn" data-bind="click: clearAll, disable: loading() || thingUrl() === ''" title="Clear Text">
                 <i class="fas fa-times-circle"></i>
             </button>
         </div>


### PR DESCRIPTION
# Issues

Closes #1 
Closes #2 

# Summary

- Output paths are now absolute rather than relative, i.e. you have to specify `models`, rather than `/home/pi/.octoprint/uploads/models` for the `Output Directory` parameter.
- More slick UI / UX changes
- Option to override the name of the Thing being downloaded.
