### PR TITLE
Octoprint Plugin PR changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ plugin_ignored_packages = []
 # Example:
 #     plugin_requires = ["someDependency==dev"]
 #     additional_setup_parameters = {"dependency_links": ["https://github.com/someUser/someRepo/archive/master.zip#egg=someDependency-dev"]}
-additional_setup_parameters = {}
+additional_setup_parameters = {"python_requires": ">=3, <4"}
 
 ########################################################################################################################
 

--- a/thingiverse_downloader/__init__.py
+++ b/thingiverse_downloader/__init__.py
@@ -155,9 +155,27 @@ class ThingiverseDownloaderPlugin(octoprint.plugin.TemplatePlugin,
 
         return self.return_response(response)
 
+    def get_update_information(*args, **kwargs):
+        return dict(
+            updateplugindemo=dict(
+                displayName=__plugin_name__,
+                displayVersion=__plugin_version__,
+
+                type="github_release",
+                current=__plugin_version__,
+                user="appdevelopmentandsuch",
+                repo="Thingiverse-Downloader",
+
+                pip="https://github.com/someUser/OctoPrint-UpdatePluginDemo/archive/{target}.zip"
+            )
+        )
+
 
 __plugin_name__ = "Thingiverse Downloader"
 __plugin_version__ = "0.2.0"
 __plugin_description__ = "Download and extract a thing from Thingiverse to your Octoprint instance, given a URL to the thing"
 __plugin_pythoncompat__ = ">=3,<4"
 __plugin_implementation__ = ThingiverseDownloaderPlugin()
+__plugin_hooks__ = {
+    "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
+}

--- a/thingiverse_downloader/templates/thingiverse_downloader_tab.jinja2
+++ b/thingiverse_downloader/templates/thingiverse_downloader_tab.jinja2
@@ -1,5 +1,4 @@
 <div class="thingiverse-downloader-column">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <div class="thingiverse-downloader-input-wrapper">
         <div class="thingiverse-downloader-input-row">
             <input 


### PR DESCRIPTION
# Summary
- Added `setup_requirements` so users can't accidentally install this in a non-python3 environment as per [comment](https://github.com/OctoPrint/plugins.octoprint.org/pull/940#issuecomment-915689458)
- Added software hook so users can update plugin when new versions are released as per [comment](https://github.com/OctoPrint/plugins.octoprint.org/pull/940#issuecomment-915693134)
- Removed unnecessary link as per [comment](https://github.com/OctoPrint/plugins.octoprint.org/pull/940#issuecomment-915693134)