### PR TITLE
Fix link to Thingiverse

### DIFF
--- a/thingiverse_downloader/templates/thingiverse_downloader_settings.jinja2
+++ b/thingiverse_downloader/templates/thingiverse_downloader_settings.jinja2
@@ -8,7 +8,7 @@
             </div>
         </div>
         <span style="width: auto">
-        Get an API key to download things from Thingiverse by logging into the Thingiverse Developer Console found <a src="https://www.thingiverse.com/developers">here</a>
+        Get an API key to download things from Thingiverse by logging into the Thingiverse Developer Console found <a href="https://www.thingiverse.com/developers">here</a>
         </span>
     </div>
     <div class="control-group thingiverse-downloader-settings-container">


### PR DESCRIPTION
Thingiverse API link did not work due to wrong attribute being used. Should be `href` for links, not `src`